### PR TITLE
Test against go-1.5.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,8 @@
 language: go
 
 go:
-  - 1.5.1
+  - 1.5.2
+  - tip
 
 before_install:
   - mv ${TRAVIS_BUILD_DIR}/server/Godeps ${TRAVIS_BUILD_DIR}
@@ -15,3 +16,7 @@ script:
 
 notifications:
   email: false
+
+matrix:
+  allow_failures:
+    - go: tip


### PR DESCRIPTION
- [x] Run tests against go-1.5.2 (go-1.5.1 can be dropped)
- [x] Run tests and allow failure running tests against git-tip.

Moving from golang-1.5.1 to golang-1.5.2 should not cause any trouble. 
