### PR TITLE
Update Mirage config for xip.io

### DIFF
--- a/client/app/mirage/config.js
+++ b/client/app/mirage/config.js
@@ -7,7 +7,7 @@ export default function() {
 
     Note: these only affect routes defined *after* them!
   */
-  this.urlPrefix = 'http://localhost:8042';    // make this `http://localhost:8080`, for example, if your API is on a different server
+  this.urlPrefix = 'http://api.127.0.0.1.xip.io:8042';    // make this `http://localhost:8080`, for example, if your API is on a different server
   this.namespace = 'api/v1';    // make this `api`, for example, if your API is namespaced
   // this.timing = 400;      // delay for each request, automatically set to 0 during testing
 


### PR DESCRIPTION
This PR fixes the Mirage configuration to stub `http://api.127.0.0.1.xip.io:8042` properly.

@bazzel this resolves the issue you mentioned on Slack. Can you verify and merge? 
